### PR TITLE
Remove unnecessary eval.

### DIFF
--- a/src/virtual_cat.jl
+++ b/src/virtual_cat.jl
@@ -3,7 +3,7 @@
 
 function virtual_cat{T}(expanded_dim::Int, parents::AbstractArray{T}...)
     dim = max(expanded_dim, largest_dim(parents...))
-    return eval(:(VirtualArray{$T, $dim}($expanded_dim, $(parents...))))
+    return VirtualArray{T, dim}(expanded_dim, parents...)
 end
 
 function virtual_cat(expanded_dim::Int)


### PR DESCRIPTION
Looks like that eval didn't need to be there. General wisdom says that eval is less good than not eval. Is there any case where you've noticed the eval being more performant?

We should consider using Benchmarks.jl and the benchmark packages at JuliaCI so we can compare revisions in the future.
